### PR TITLE
Extend Dates standard lib functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,24 +12,40 @@ julia> using Dates, PenultimateDays
 julia> d = today()
 2022-06-24
 
-julia> penultimatedayofweek(d)
+julia> penultimatedayofweek(d)  # second-to-last day of the week
 2022-06-25
 
-julia> penultimatedayofmonth(d)
+julia> penultimatedayofmonth(d)  # second-to-last day of the month
 2022-06-29
 
-julia> penultimatedayofmonth(d, Tuesday)
+julia> penultimatedayofmonth(d, Tuesday)  # second-to-last Tuesday of the month
 2022-06-21
 
-julia> penultimatedayofquarter(d)
+julia> penultimatedayofquarter(d)  # second-to-last day of the quarter
 2022-06-29
 
-julia> penultimatedayofquarter(d, Tuesday)
+julia> penultimatedayofquarter(d, Tuesday)  # second-to-last Tuesday of the quarter
 2022-06-21
 
-julia> penultimatedayofyear(d)
+julia> penultimatedayofyear(d)  # second-to-last day of the year
 2022-12-31
 
-julia> penultimatedayofyear(d, Tuesday)
+julia> penultimatedayofyear(d, Tuesday)  # second-to-last Tuesday of the year
 2022-12-20
+```
+
+## Extending the Dates standard library
+
+We have also extended the Dates standard library to allow specification of day for `*dayof*` functions:
+```julia
+julia> using Dates, PenultimateDays
+
+julia> d = today()
+2022-06-24
+
+julia> firstdayofmonth(d, Tuesday)
+2022-06-07
+
+julia> lastdayofmonth(d, Tuesday)
+2022-06-28
 ```

--- a/src/PenultimateDays.jl
+++ b/src/PenultimateDays.jl
@@ -13,24 +13,34 @@ end
 
 for m in (:first, :last), t in (:week, :month, :quarter, :year)
     ef = Symbol("$(m)dayof$(t)")
-    @eval begin
-        import Dates: $ef
-        export $ef
-    end
+    @eval import Dates: $ef
 end
 
+## Week
 function firstdayofweek(dt::TimeType, d::Int)
     fd_date = firstdayofweek(dt)
     return fd_date + Day(d - 1)
 end
+
 lastdayofweek(dt::TimeType, d::Int) = firstdayofweek(dt, d)
 
+## Month
 function firstdayofmonth(dt::TimeType, d::Int)
     fd_date = firstdayofmonth(dt)
     fd_i = dayofweek(fd_date)
-    fd_day = d - fd_i + 1
-    fd_i > d && (fd_day += 7)
+    fd_day = d - fd_i + 1 + 7(fd_i > d)
     return fd_date + Day(fd_day - 1)
 end
+
+function lastdayofmonth(dt::TimeType, d::Int)
+    ld_date = lastdayofmonth(dt)
+    ld_i = dayofweek(ld_date)
+    ld_day = 7(ld_i < d) - d + ld_i + 1
+    return ld_date - Day(ld_day - 1)
+end
+
+## Quarter
+
+## Year
 
 end  # end module

--- a/src/PenultimateDays.jl
+++ b/src/PenultimateDays.jl
@@ -46,4 +46,7 @@ lastdayofquarter(dt::TimeType, d::Int) = lastdayofmonth(lastdayofquarter(dt), d)
 
 ## Year
 
+firstdayofyear(dt::TimeType, d::Int) = firstdayofmonth(firstdayofyear(dt), d)
+lastdayofyear(dt::TimeType, d::Int) = lastdayofmonth(lastdayofyear(dt), d)
+
 end  # end module

--- a/src/PenultimateDays.jl
+++ b/src/PenultimateDays.jl
@@ -41,6 +41,9 @@ end
 
 ## Quarter
 
+firstdayofquarter(dt::TimeType, d::Int) = firstdayofmonth(firstdayofquarter(dt), d)
+lastdayofquarter(dt::TimeType, d::Int) = lastdayofmonth(lastdayofquarter(dt), d)
+
 ## Year
 
 end  # end module

--- a/src/PenultimateDays.jl
+++ b/src/PenultimateDays.jl
@@ -9,17 +9,22 @@ for t in (:week, :month, :quarter, :year)
     @eval export $pf
 end
 
-for t in (:week, :month, :quarter, :year)
-    for m in (:first, :last)
-        ef = Symbol("$(m)dayof$(t)")
-        @eval begin
-            import Dates: $ef
-            function $ef(dt::TimeType, d::Int)
-                error("not yet implemented")
-            end
-            export $ef
-        end
+# Dates (stdlib) extended
+
+for m in (:first, :last), t in (:week, :month, :quarter, :year)
+    ef = Symbol("$(m)dayof$(t)")
+    @eval begin
+        import Dates: $ef
+        export $ef
     end
+end
+
+function firstdayofmonth(dt::TimeType, d::Int)
+    fd_date = firstdayofmonth(dt)
+    fd_i = dayofweek(fd_date)
+    fd_day = d - fd_i + 1
+    fd_i > d && (fd_day += 7)
+    return fd_date + Day(fd_day - 1)
 end
 
 end  # end module

--- a/src/PenultimateDays.jl
+++ b/src/PenultimateDays.jl
@@ -19,6 +19,12 @@ for m in (:first, :last), t in (:week, :month, :quarter, :year)
     end
 end
 
+function firstdayofweek(dt::TimeType, d::Int)
+    fd_date = firstdayofweek(dt)
+    return fd_date + Day(d - 1)
+end
+lastdayofweek(dt::TimeType, d::Int) = firstdayofweek(dt, d)
+
 function firstdayofmonth(dt::TimeType, d::Int)
     fd_date = firstdayofmonth(dt)
     fd_i = dayofweek(fd_date)

--- a/src/PenultimateDays.jl
+++ b/src/PenultimateDays.jl
@@ -7,11 +7,18 @@ for t in (:week, :month, :quarter, :year)
     @eval $pf(dt::TimeType) = error("not yet implemented")
     @eval $pf(dt::TimeType, d::Int) = error("not yet implemented")
     @eval export $pf
+end
+
+for t in (:week, :month, :quarter, :year)
     for m in (:first, :last)
         ef = Symbol("$(m)dayof$(t)")
-        @eval import Dates: $ef
-        @eval $ef(dt::TimeType, d::Int) = error("not yet implemented")
-        @eval export $ef
+        @eval begin
+            import Dates: $ef
+            function $ef(dt::TimeType, d::Int)
+                error("not yet implemented")
+            end
+            export $ef
+        end
     end
 end
 

--- a/src/PenultimateDays.jl
+++ b/src/PenultimateDays.jl
@@ -3,17 +3,27 @@ module PenultimateDays
 using Dates
 
 for t in (:week, :month, :quarter, :year)
-    pf = Symbol("penultimatedayof$(t)")
-    @eval $pf(dt::TimeType) = error("not yet implemented")
-    @eval $pf(dt::TimeType, d::Int) = error("not yet implemented")
-    @eval export $pf
+    f = Symbol("penultimatedayof$(t)")
+    @eval $f(dt::TimeType) = error("not yet implemented")
+    @eval $f(dt::TimeType, d::Int) = error("not yet implemented")
+    @eval export $f
 end
 
 # Dates (stdlib) extended
 
 for m in (:first, :last), t in (:week, :month, :quarter, :year)
-    ef = Symbol("$(m)dayof$(t)")
-    @eval import Dates: $ef
+    f = Symbol("$(m)dayof$(t)")
+    ms, ts = string(m), string(t)
+    @eval begin 
+        import Dates: $f
+        
+        @doc """
+            $($f)(datetime::TimeType, day::Int)
+        
+        Find the $($ms) day of the $($ts) that is a (Monday = 1, Tuesday = 2, &c.).
+        """
+        $f
+    end
 end
 
 ## Week

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,18 @@ using Dates
 using PenultimateDays
 using Test
 
+#=Test.eval(quote
+	function record(ts::DefaultTestSet, t::Error)  # t::Union{Fail, Error}
+        if t isa Error
+            e = only(match(r"^(\w+)\(.*\)$", t.value).captures)
+            if e == "ErrorException" # || e == "MethodError"
+                push!(ts.results, t)
+            end
+        end
+	end
+end)
+=#
+
 @testset "PenultimateDays.jl" begin
     d1 = Date(2022, 6, 24)
     d2 = Date(2023, 1, 12)
@@ -30,6 +42,10 @@ using Test
     end
     
     @testset "Day-specific Penultimate Functions" begin
+        # Week
+        ## Cannot have a second to last specified day in a week, which
+        ## only contains one of each day
+        
         # Month
         @test penultimatedayofmonth(d1, Monday) == Date(2022, 6, 20)
         @test penultimatedayofmonth(d1, Wednesday) == Date(2022, 6, 22)
@@ -65,6 +81,26 @@ using Test
     end
     
     @testset "Dates (stdlib) Extended" begin
+        # Week
+        @test firstdayofweek(d1, Monday) == Date(2022, 6, 20)
+        @test firstdayofweek(d1, Wednesday) == Date(2022, 6, 22)
+        @test firstdayofweek(d1, Sunday) == Date(2022, 6, 26)
+        @test firstdayofweek(d2, Monday) == Date(2023, 1, 9)
+        @test firstdayofweek(d2, Wednesday) == Date(2023, 1, 11)
+        @test firstdayofweek(d2, Sunday) == Date(2023, 1, 15)
+        @test firstdayofweek(d3, Monday) == Date(2033, 2, 7)
+        @test firstdayofweek(d3, Wednesday) == Date(2033, 2, 9)
+        @test firstdayofweek(d3, Sunday) == Date(2033, 2, 13)
+        @test lastdayofweek(d1, Monday) == Date(2022, 6, 20)
+        @test lastdayofweek(d1, Wednesday) == Date(2022, 6, 22)
+        @test lastdayofweek(d1, Sunday) == Date(2022, 6, 26)
+        @test lastdayofweek(d2, Monday) == Date(2023, 1, 9)
+        @test lastdayofweek(d2, Wednesday) == Date(2023, 1, 11)
+        @test lastdayofweek(d2, Sunday) == Date(2023, 1, 15)
+        @test lastdayofweek(d3, Monday) == Date(2033, 2, 7)
+        @test lastdayofweek(d3, Wednesday) == Date(2033, 2, 9)
+        @test lastdayofweek(d3, Sunday) == Date(2033, 2, 13)
+        
         # Month
         @test firstdayofmonth(d1, Monday) == Date(2022, 6, 6)
         @test firstdayofmonth(d1, Wednesday) == Date(2022, 6, 1)


### PR DESCRIPTION
Extend Dates (stdlib) functionality to allow for specification of first/last day of week/month/quarter/year.  (Previously these Dates functions would simply find the first/last day of a unit of time given the a date time object.)

The generic signature we are extending to allow is `*dayof*(dt::TimeType, d::Int)`, so that one can specify the day (as an integer) which they wish to find the first/last of.

For example, the first Sunday of June, 2022 is the 5th, and the last is the 28th:
```
      May 2022             June 2022             July 2022
Su Mo Tu We Th Fr Sa  Su Mo Tu We Th Fr Sa  Su Mo Tu We Th Fr Sa
 1  2  3  4  5  6  7            1  2  3  4                  1  2
 8  9 10 11 12 13 14   5  6  7  8  9 10 11   3  4  5  6  7  8  9
15 16 17 18 19 20 21  12 13 14 15 16 17 18  10 11 12 13 14 15 16
22 23 24 25 26 27 28  19 20 21 22 23 24 25  17 18 19 20 21 22 23
29 30 31              26 27 28 29 30        24 25 26 27 28 29 30
                                            31
```
```julia
julia> using Dates

julia> firstdayofmonth(Date(2022, June), Sunday)  # June = 6, Sunday = 7
2022-06-05

julia> lastdayofmonth(Date(2022, June), Tuesday)  # Tuesday = 2
2022-06-28
```

These functions are implemented in linear time&mdash;$O(1)$&mdash;, and are very useful in implementing the `penultimatedayof*` methods (which will be implemented next!)