### PR TITLE
Implement trivial penultimate functions

### DIFF
--- a/src/PenultimateDays.jl
+++ b/src/PenultimateDays.jl
@@ -11,9 +11,13 @@ for m in (:first, :last), t in (:week, :month, :quarter, :year)
         import Dates: $f
         
         @doc """
-            $($f)(datetime::TimeType, day::Int)
+            $($f)(dt::TimeType, d::Int) -> TimeType
         
-        Find the $($ms) day of the $($ts) that is a (Monday = 1, Tuesday = 2, &c.).
+        Adjusts `dt` to the $($ms) `d`-day of its $($ts), given some `d`, the day of the week as an `Int`, with `1 = Monday, 2 = Tuesday, &c...`
+        
+        For example, the `$($f)(dt, 6)` will find the $($ms) Saturday of the $($ts).  Dates also exports integer aliases `Monday`–`Sunday`, so you can write `$($f)(dt, Saturday)`.
+        
+        See also: `Dates.dayofweek`
         """
         $f
     end
@@ -60,9 +64,9 @@ for t in (:week, :month, :quarter, :year)
     ts = string(t)
     @eval begin 
         @doc """
-            $($f)(datetime::TimeType)
+            $($f)(dt::TimeType) -> TimeType
         
-        Adjusts dt to the penultimate (second-to-last) day of its $($ts).
+        Adjusts `dt` to the penultimate (second-to-last) day of its $($ts).
         """
         $f(dt::TimeType) = $f′(dt) - Day(1)
         export $f

--- a/src/PenultimateDays.jl
+++ b/src/PenultimateDays.jl
@@ -2,13 +2,6 @@ module PenultimateDays
 
 using Dates
 
-for t in (:week, :month, :quarter, :year)
-    f = Symbol("penultimatedayof$(t)")
-    @eval $f(dt::TimeType) = error("not yet implemented")
-    @eval $f(dt::TimeType, d::Int) = error("not yet implemented")
-    @eval export $f
-end
-
 # Dates (stdlib) extended
 
 for m in (:first, :last), t in (:week, :month, :quarter, :year)
@@ -58,5 +51,22 @@ lastdayofquarter(dt::TimeType, d::Int) = lastdayofmonth(lastdayofquarter(dt), d)
 
 firstdayofyear(dt::TimeType, d::Int) = firstdayofmonth(firstdayofyear(dt), d)
 lastdayofyear(dt::TimeType, d::Int) = lastdayofmonth(lastdayofyear(dt), d)
+
+
+# Trivial Penultimate Functions
+
+for t in (:week, :month, :quarter, :year)
+    f, f′ = Symbol("penultimatedayof$(t)"), Symbol("lastdayof$(t)")
+    ts = string(t)
+    @eval begin 
+        @doc """
+            $($f)(datetime::TimeType)
+        
+        Adjusts dt to the penultimate (second-to-last) day of its $($ts).
+        """
+        $f(dt::TimeType) = $f′(dt) - Day(1)
+        export $f
+    end
+end
 
 end  # end module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,7 +23,7 @@ end)
         # Week
         @test penultimatedayofweek(d1) == Date(2022, 6, 25)
         @test penultimatedayofweek(d2) == Date(2023, 1, 14)
-        @test penultimatedayofweek(d3) == Date(2023, 2, 12)
+        @test penultimatedayofweek(d3) == Date(2033, 2, 12)
         
         # Month
         @test penultimatedayofmonth(d1) == Date(2022, 6, 29)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,6 +18,7 @@ end)
     d1 = Date(2022, 6, 24)
     d2 = Date(2023, 1, 12)
     d3 = Date(2033, 2, 7)
+    dt = DateTime("1996-01-05T12:30:00")
     
     @testset "Trivial Penultimate Functions" begin
         # Week
@@ -39,6 +40,12 @@ end)
         @test penultimatedayofyear(d1) == Date(2022, 12, 30)
         @test penultimatedayofyear(d2) == Date(2023, 12, 30)
         @test penultimatedayofyear(d3) == Date(2033, 12, 30)
+        
+        # Time type
+        @test penultimatedayofweek(dt) isa typeof(dt)
+        @test penultimatedayofmonth(dt) isa typeof(dt)
+        @test penultimatedayofquarter(dt) isa typeof(dt)
+        @test penultimatedayofyear(dt) isa typeof(dt)
     end
     
     @testset "Day-specific Penultimate Functions" begin
@@ -78,6 +85,12 @@ end)
         @test penultimatedayofyear(d3, Monday) == Date(2033, 12, 19)
         @test penultimatedayofyear(d3, Wednesday) == Date(2033, 12, 21)
         @test penultimatedayofyear(d3, Sunday) == Date(2033, 12, 18)
+        
+        # Time type
+        @test penultimatedayofweek(dt, Tuesday) isa typeof(dt)
+        @test penultimatedayofmonth(dt, Tuesday) isa typeof(dt)
+        @test penultimatedayofquarter(dt, Tuesday) isa typeof(dt)
+        @test penultimatedayofyear(dt, Tuesday) isa typeof(dt)
     end
     
     @testset "Dates (stdlib) Extended" begin
@@ -160,5 +173,15 @@ end)
         @test lastdayofyear(d3, Monday) == Date(2033, 12, 26)
         @test lastdayofyear(d3, Wednesday) == Date(2033, 12, 28)
         @test lastdayofyear(d3, Sunday) == Date(2033, 12, 25)
+        
+        # Time type
+        @test firstdayofweek(dt, Tuesday) isa typeof(dt)
+        @test lastdayofweek(dt, Tuesday) isa typeof(dt)
+        @test firstdayofmonth(dt, Tuesday) isa typeof(dt)
+        @test lastdayofmonth(dt, Tuesday) isa typeof(dt)
+        @test firstdayofquarter(dt, Tuesday) isa typeof(dt)
+        @test lastdayofquarter(dt, Tuesday) isa typeof(dt)
+        @test firstdayofyear(dt, Tuesday) isa typeof(dt)
+        @test lastdayofyear(dt, Tuesday) isa typeof(dt)
     end
 end


### PR DESCRIPTION
Implement trivial penultimate functions, whose signature is `penultimatedayof*(dt::TimeType)`, where the result is 1 day less than the corresponding `lastdayof*` function from the Dates stdlib.