### PR TITLE
Implement day-specific penultimate functions

### DIFF
--- a/src/PenultimateDays.jl
+++ b/src/PenultimateDays.jl
@@ -81,17 +81,24 @@ end
 penultimatedayofweek(dt::TimeType, d::Int) = 
     throw(ArgumentError("It is impossible to find the second-to-last day of a week (specifying the day) wth necessarily only one of each days in the week"))
 
-## Month
+## Month, Quarter, and Year
 
-"""
-    penultimatedayofmonth(dt::TimeType) -> TimeType
-
-Adjusts `dt` to the penultimate (second-to-last) day of its month, given some `d`, the day of the week as an `Int`, with `1 = Monday, 2 = Tuesday, &c...`
-
-For example, the `penultimatedayofmonth(dt, 6)` will find the penultimate Saturday of the month.  Dates also exports integer aliases `Monday`–`Sunday`, so you can write `penultimatedayofmonth(dt, Saturday)`.
+for t in (:month, :quarter, :year)
+    f, f′ = Symbol("penultimatedayof$(t)"), Symbol("lastdayof$(t)")
+    ts = string(t)
+    @eval begin
+        @doc """
+            $($f)(dt::TimeType, d::Int) -> TimeType
         
-See also: `Dates.dayofweek`, `lastdayofmonth`
-"""
-penultimatedayofmonth(dt::TimeType, d::Int) = lastdayofmonth(dt, d) - Week(1)
+        Adjusts `dt` to the penultimate (second-to-last) day of its $($ts), given some `d`, the day of the week as an `Int`, with `1 = Monday, 2 = Tuesday, &c...`
+        
+        For example, the `$($f)(dt, 6)` will find the penultimate Saturday of the $($ts).  Dates also exports integer aliases `Monday`–`Sunday`, so you can write `$($f)(dt, Saturday)`.
+                
+        See also: `Dates.dayofweek`, `$($f′)`
+        """
+        $f(dt::TimeType, d::Int) = $f′(dt, d) - Week(1)
+    end
+end
 
 end  # end module
+

--- a/src/PenultimateDays.jl
+++ b/src/PenultimateDays.jl
@@ -73,4 +73,20 @@ for t in (:week, :month, :quarter, :year)
     end
 end
 
+
+# Day-specific Penultimate Functions
+
+## Month
+
+"""
+    penultimatedayofmonth(dt::TimeType) -> TimeType
+
+Adjusts `dt` to the penultimate (second-to-last) day of its month, given some `d`, the day of the week as an `Int`, with `1 = Monday, 2 = Tuesday, &c...`
+
+For example, the `penultimatedayofmonth(dt, 6)` will find the penultimate Saturday of the month.  Dates also exports integer aliases `Monday`–`Sunday`, so you can write `penultimatedayofmonth(dt, Saturday)`.
+        
+See also: `Dates.dayofweek`, `lastdayofmonth`
+"""
+penultimatedayofmonth(dt::TimeType, d::Int) = lastdayofmonth(dt, d) - Week(1)
+
 end  # end module

--- a/src/PenultimateDays.jl
+++ b/src/PenultimateDays.jl
@@ -76,6 +76,11 @@ end
 
 # Day-specific Penultimate Functions
 
+## Week
+
+penultimatedayofweek(dt::TimeType, d::Int) = 
+    throw(ArgumentError("It is impossible to find the second-to-last day of a week (specifying the day) wth necessarily only one of each days in the week"))
+
 ## Month
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -68,11 +68,11 @@ end)
         # Quarter
         @test penultimatedayofquarter(d1, Monday) == Date(2022, 6, 20)
         @test penultimatedayofquarter(d1, Wednesday) == Date(2022, 6, 22)
-        @test penultimatedayofquarter(d1, Sunday) == Date(2022, 19)
+        @test penultimatedayofquarter(d1, Sunday) == Date(2022, 6, 19)
         @test penultimatedayofquarter(d2, Monday) == Date(2023, 3, 20)
         @test penultimatedayofquarter(d2, Wednesday) == Date(2023, 3, 22)
         @test penultimatedayofquarter(d2, Sunday) == Date(2023, 3, 19)
-        @test penultimatedayofquarter(d3, Monday) == Date(2033, 3, 20)
+        @test penultimatedayofquarter(d3, Monday) == Date(2033, 3, 21)
         @test penultimatedayofquarter(d3, Wednesday) == Date(2033, 3, 23)
         @test penultimatedayofquarter(d3, Sunday) == Date(2033, 3, 20)
         

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -52,6 +52,7 @@ end)
         # Week
         ## Cannot have a second to last specified day in a week, which
         ## only contains one of each day
+        @test_throws ArgumentError penultimatedayofweek(d1, Tuesday)
         
         # Month
         @test penultimatedayofmonth(d1, Monday) == Date(2022, 6, 20)
@@ -87,7 +88,6 @@ end)
         @test penultimatedayofyear(d3, Sunday) == Date(2033, 12, 18)
         
         # Time type
-        @test penultimatedayofweek(dt, Tuesday) isa typeof(dt)
         @test penultimatedayofmonth(dt, Tuesday) isa typeof(dt)
         @test penultimatedayofquarter(dt, Tuesday) isa typeof(dt)
         @test penultimatedayofyear(dt, Tuesday) isa typeof(dt)


### PR DESCRIPTION
Implement day-specific penultimate functions.  That is, implement `penultimatedayof*` functions, for month, quarter, and year.  The signature here is `penultimatedayof*(dt::TimeType, d::Int)`, where you specify `d` to represent a day of the week.  For example, `penultimatedayofmonth(dt, Tuesday)` will find the second-to-last Tuesday of the month.